### PR TITLE
Better links to sources in reports

### DIFF
--- a/threatspec/config.py
+++ b/threatspec/config.py
@@ -7,14 +7,14 @@ class Project():
 class Import():
     def __init__(self, obj):
         self.path = ""
-        
+
         if isinstance(obj, str):
             self.path = obj
         elif isinstance(obj, dict):
             if "path" not in obj:
                 raise ValueError("path key missing from import")
             self.path = obj["path"]
-            
+
 
 class Path():
     def __init__(self, obj):
@@ -44,6 +44,7 @@ class Config():
         self.project = None
         self.imports = []
         self.paths = []
+        self.repository_url = ""
 
     def load(self, data):
         self.project = Project(data["project"]["name"], data["project"]["description"])
@@ -52,3 +53,5 @@ class Config():
                 self.imports.append(Import(import_path))
         for path in data["paths"]:
             self.paths.append(Path(path))
+        if "repository_url" in data["project"]:
+            self.repository_url = data["project"]["repository_url"]

--- a/threatspec/report_templates/default_markdown.md
+++ b/threatspec/report_templates/default_markdown.md
@@ -27,7 +27,11 @@
 ```
 {{ exposure.source.code }}
 ```
+{% if report.repository_url %}
+[{{ exposure.source.filename }}:{{ exposure.source.line }}]({{ report.repository_url }}/{{ exposure.source.filename }}#L{{ exposure.source.line }})
+{% else %}
 {{ exposure.source.filename }}:{{ exposure.source.line }}
+{% endif %}
 {% endfor %}
 
 # Acceptances
@@ -49,7 +53,11 @@
 ```
 {{ acceptance.source.code }}
 ```
+{% if report.repository_url %}
+[{{ acceptance.source.filename }}:{{ acceptance.source.line }}]({{ report.repository_url }}/{{ acceptance.source.filename }}#L{{ acceptance.source.line }})
+{% else %}
 {{ acceptance.source.filename }}:{{ acceptance.source.line }}
+{% endif %}
 {% endfor %}
 
 # Transfers
@@ -71,7 +79,11 @@
 ```
 {{ transfer.source.code }}
 ```
+{% if report.repository_url %}
+[{{ transfer.source.filename }}:{{ transfer.source.line }}]({{ report.repository_url }}/{{ transfer.source.filename }}#L{{ transfer.source.line }})
+{% else %}
 {{ transfer.source.filename }}:{{ transfer.source.line }}
+{% endif %}
 {% endfor %}
 
 # Mitigations
@@ -93,7 +105,11 @@
 ```
 {{ mitigation.source.code }}
 ```
+{% if report.repository_url %}
+[{{ mitigation.source.filename }}:{{ mitigation.source.line }}]({{ report.repository_url }}/{{ mitigation.source.filename }}#L{{ mitigation.source.line }})
+{% else %}
 {{ mitigation.source.filename }}:{{ mitigation.source.line }}
+{% endif %}
 {%- if mitigation.tests %}
 ### Tests
 {% for test in mitigation.tests %}
@@ -105,7 +121,11 @@
 ```
 {{ test.source.code }}
 ```
+{% if report.repository_url %}
+[{{ test.source.filename }}:{{ test.source.line }}]({{ report.repository_url }}/{{ test.source.filename }}#L{{ test.source.line }})
+{% else %}
 {{ test.source.filename }}:{{ test.source.line }}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% endfor %}
@@ -113,7 +133,11 @@
 # Reviews
 {% for review in report.threatmodel.reviews %}
 ## {{ review.component.name }}
+
 {{ review.details }}
+
+{{ review.description }}
+
 {%- if review.custom %}
 | Custom Key | Value |
 | --- | --- |
@@ -125,7 +149,11 @@
 ```
 {{ review.source.code }}
 ```
+{% if report.repository_url %}
+[{{ review.source.filename }}:{{ review.source.line }}]({{ report.repository_url }}/{{ review.source.filename }}#L{{ review.source.line }})
+{% else %}
 {{ review.source.filename }}:{{ review.source.line }}
+{% endif %}
 {% endfor %}
 
 # Connections
@@ -143,7 +171,11 @@
 ```
 {{ connection.source.code }}
 ```
+{% if report.repository_url %}
+[{{ connection.source.filename }}:{{ connection.source.line }}]({{ report.repository_url }}/{{ connection.source.filename }}#L{{ connection.source.line }})
+{% else %}
 {{ connection.source.filename }}:{{ connection.source.line }}
+{% endif %}
 {% endfor %}
 
 # Components


### PR DESCRIPTION
I noticed that threatspec prints absolute paths to files in reports. It can disclose user's home directory path and user's ID. Instead, it may be better to print a relative path in the code repository. Or even better, reports may contain clickable links to the files.

Here is what the patch introduces:

- Updated the parsers to store only relative paths to files.
- Introduced a new `repository_url` configuration parameter which contains a URL to the source code repository (for example, on public GitHub or GitHub Enterprise).
- Updated the Markdown report template to use a URL to the source code repository (if present) while building links to sources.

(the files contain some trailing spaces which my text editor kindly removed - I hope it's fine)