### PR TITLE
Fix Dockerized threatspec execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
-FROM python:3.7-alpine
-RUN pip3 install threatspec
-RUN apk update && apk add graphviz && rm -rf /var/cache/apk/*
+FROM python:3.8-buster
+RUN pip3 install threatspec && apt-get update && apt-get install -y graphviz && rm -rf /var/lib/apt/lists/*
+WORKDIR /data
+ENTRYPOINT ["threatspec"]


### PR DESCRIPTION
- Changed from Alpine Linux to Debian Buster, because Alpine Linux' graphviz package does not use gsfonts library and hence diagrams were generated without any text glyphs.
- Updated Python version from 3.7 to 3.8.
- Added docker entrypoint directly to threatspec to make the container image easier to use.
- Improved installation container layering
- Defaulting the default container work directory to /data.

# Example use
```
docker build -t threatspec -f Dockerfile .
docker run --rm -v `pwd`:/data -t threatspec run
```